### PR TITLE
fix: stabilize govulncheck execution and enforce Go 1.26 toolchain

### DIFF
--- a/cmd/govulncheck.go
+++ b/cmd/govulncheck.go
@@ -17,28 +17,57 @@ var govulncheckCmd = &cobra.Command{
 		color.Cyan("[INFO] Checking for vulnerabilities in dependencies...")
 		fmt.Println("")
 
-		// selalu reinstall govulncheck biar sesuai versi Go yang aktif
-		color.Cyan("[INFO] Installing/updating govulncheck...")
-		install := exec.Command("go", "install", "golang.org/x/vuln/cmd/govulncheck@latest")
-		install.Stdout = os.Stdout
-		install.Stderr = os.Stderr
-		if err := install.Run(); err != nil {
-			color.Red("❌ Failed to install govulncheck: %v", err)
-			return
+		// cek binary govulncheck
+		path, err := exec.LookPath("govulncheck")
+		if err != nil {
+			color.Red("❌ govulncheck not installed")
+
+			color.Cyan("[INFO] Installing govulncheck with Go 1.26 toolchain...")
+
+			install := exec.Command(
+				"go",
+				"install",
+				"golang.org/x/vuln/cmd/govulncheck@latest",
+			)
+
+			// paksa pakai toolchain lokal (NO auto-switch)
+			install.Env = append(os.Environ(),
+				"GOTOOLCHAIN=local",
+				"CGO_ENABLED=1",
+			)
+
+			install.Stdout = os.Stdout
+			install.Stderr = os.Stderr
+
+			if err := install.Run(); err != nil {
+				color.Red("❌ Failed to install govulncheck: %v", err)
+				return
+			}
+
+			color.Green("[OK] govulncheck installed.")
+			fmt.Println("")
+		} else {
+			color.Green("[OK] govulncheck found at: %s", path)
 		}
-		color.Green("[OK] govulncheck ready.")
+
 		fmt.Println("")
 
-		// jalankan govulncheck
+		// jalankan tanpa reinstall, tanpa noise toolchain switch
 		check := exec.Command("govulncheck", "./...")
+
+		check.Env = append(os.Environ(),
+			"GOTOOLCHAIN=local",
+			"CGO_ENABLED=1",
+		)
+
 		check.Stdout = os.Stdout
 		check.Stderr = os.Stderr
 
 		if err := check.Run(); err != nil {
 			fmt.Println("")
-			color.Red("❌ Vulnerabilities found! Fix them by running:")
-			fmt.Println("   go get -u ./...")
-			fmt.Println("   go mod tidy")
+			color.Red("❌ govulncheck detected issues (or tool mismatch)")
+			fmt.Println("   If this looks like a toolchain error, rebuild govulncheck:")
+			fmt.Println("   go install golang.org/x/vuln/cmd/govulncheck@latest")
 			fmt.Println("")
 			return
 		}


### PR DESCRIPTION
- Stop reinstalling govulncheck on every command execution
- Add exec.LookPath check to reuse existing binary
- Enforce GOTOOLCHAIN=local to prevent automatic toolchain switching
- Fix mismatch issue between Go 1.25 vs Go 1.26 govulncheck builds
- Improve cross-platform compatibility (Linux/Windows)
- Ensure deterministic behavior for Goarchi CLI tooling