### PR TITLE
feat: add seeder system and improve CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# 📦 Goarchi
+# Goarchi
 
 > Simple Layered Architecture Generator for Golang
 
-Goarchi is a CLI tool that helps you scaffold a clean, layered Go project structure — controllers, services, models, migrations, requests, and resources — in seconds.
+Goarchi is a CLI tool that helps you scaffold a clean, layered Go project structure — controllers, services, models, migrations, requests, resources, and seeders — in seconds.
 
 ---
 
-## 📋 Requirements
+## Requirements
 
 - Go `1.26.3` or higher
 
 ---
 
-## 🚀 Getting Started
+## Getting Started
 
 ### 1. Create a new project
 
@@ -37,12 +37,6 @@ Build the binary from inside your project:
 
 ```bash
 go run cli/main.go build
-```
-
-Output:
-```
-📦 Building Goarchi binary...
-✅ Binary generated successfully!
 ```
 
 Move binary to PATH:
@@ -95,7 +89,7 @@ go run main.go
 
 ---
 
-## 🔧 Usage
+## Usage
 
 ```bash
 goarchi make [command] [name] [fields...]
@@ -103,7 +97,7 @@ goarchi make [command] [name] [fields...]
 
 ### Available Commands
 
-#### 🔧 Controller
+#### Controller
 ```bash
 goarchi make controller [name]
 ```
@@ -112,12 +106,12 @@ Generates a controller file at `app/controllers/[name]_controller.go`.
 **Example:**
 ```bash
 goarchi make controller user
-# → app/controllers/user_controller.go (struct: UserController)
+# -> app/controllers/user_controller.go (struct: UserController)
 ```
 
 ---
 
-#### 🛠️ Service
+#### Service
 ```bash
 goarchi make service [name]
 ```
@@ -126,12 +120,12 @@ Generates a service file at `app/services/[name]_service.go`.
 **Example:**
 ```bash
 goarchi make service user
-# → app/services/user_service.go (struct: UserService)
+# -> app/services/user_service.go (struct: UserService)
 ```
 
 ---
 
-#### 📝 Request
+#### Request
 ```bash
 goarchi make request [name] [field:type...]
 ```
@@ -140,12 +134,12 @@ Generates a request struct with validation tags at `app/requests/[name]_request.
 **Example:**
 ```bash
 goarchi make request user name:string age:int email:string
-# → app/requests/user_request.go (struct: UserRequest)
+# -> app/requests/user_request.go (struct: UserRequest)
 ```
 
 ---
 
-#### 📦 Resource
+#### Resource
 ```bash
 goarchi make resource [name] [field:type...]
 ```
@@ -154,12 +148,12 @@ Generates a response formatter (DTO) at `app/resources/[name]_resource.go`.
 **Example:**
 ```bash
 goarchi make resource user id:int name:string email:string
-# → app/resources/user_resource.go (struct: UserResource)
+# -> app/resources/user_resource.go (struct: UserResource)
 ```
 
 ---
 
-#### 🧩 Model
+#### Model
 ```bash
 goarchi make model [name] [field:type;gorm_tag...]
 ```
@@ -168,18 +162,18 @@ Generates a GORM model at `app/models/[name].go`. `CreatedAt` and `UpdatedAt` ar
 **Example:**
 ```bash
 goarchi make model users "id:int;primaryKey" "name:string;not null"
-# → app/models/users.go (struct: User)
+# -> app/models/users.go (struct: User)
 ```
 
 For relations (foreign key):
 ```bash
 goarchi make model users "Role:foreignKey:RoleID"
-# → adds: Role Role `gorm:"foreignKey:RoleID"`
+# -> adds: Role *Role `gorm:"foreignKey:RoleID"`
 ```
 
 ---
 
-#### 🗃️ Migration (Generate file)
+#### Migration (Generate file)
 ```bash
 goarchi make migration [name]
 ```
@@ -188,32 +182,82 @@ Generates a timestamped migration file at `database/migrations/[timestamp]_[name
 **Example:**
 ```bash
 goarchi make migration create_users_table
-# → database/migrations/20240101120000_create_users_table.go
+# -> database/migrations/20240101120000_create_users_table.go
+```
+
+Don't forget to register it in `database/migrations/migrations_list.go`:
+```go
+{
+    Name: "create_users_table",
+    Up:   CreateUsersTable,
+    Down: DropUsersTable,
+}
 ```
 
 ---
 
-#### 🧬 Migrate (Run)
+#### Seeder (Generate file)
 ```bash
+goarchi make seeder [name]
+```
+Generates a timestamped seeder file at `database/seeders/[timestamp]_[name].go`.
+
+**Example:**
+```bash
+goarchi make seeder role_seeder
+# -> database/seeders/20240101120000_role_seeder.go
+```
+
+Don't forget to register it in `database/seeders/seeder_list.go`:
+```go
+{
+    Name: "role_seeder",
+    Up:   SeedRoleSeeder,
+    Down: DropSeedRoleSeeder,
+}
+```
+
+---
+
+#### Migrate (Run)
+```bash
+# Run all migrations
 go run cli/main.go migrate up
 go run cli/main.go migrate down
+
+# Run a specific migration
+go run cli/main.go migrate up create_users_table
+go run cli/main.go migrate down create_users_table
 ```
-Runs all migrations registered in `database/migrations/migrations_list.go`.
 
-- `up` — applies all migrations in `AllMigrations`
-- `down` — rolls back all migrations in `AllMigrations`
+- `up` — applies migrations
+- `down` — drops tables
+- Optionally pass a migration name to run only that one
 
-> ⚠️ Migrate is run via `go run cli/main.go` not from the `goarchi` binary. This is because Go compiles to a static binary and cannot access migration files added after build time.
+> Migrate is run via `go run cli/main.go` not from the `goarchi` binary. This is because Go compiles to a static binary and cannot access migration files added after build time.
 
 ---
 
-#### 🔍 Check Vulnerabilities
+#### Seed (Run)
+```bash
+# Run all seeders
+go run cli/main.go seed up
+go run cli/main.go seed down
+
+# Run a specific seeder
+go run cli/main.go seed up role_seeder
+go run cli/main.go seed down role_seeder
+```
+
+- `up` — inserts seed data
+- `down` — removes seed data
+- Optionally pass a seeder name to run only that one
+
+---
+
+#### Check Vulnerabilities
 ```bash
 goarchi govulncheck
-```
-or
-```bash
-go run cli/main.go govulncheck
 ```
 
 Automatically installs/updates `govulncheck` and scans all dependencies for known vulnerabilities.
@@ -226,7 +270,7 @@ go mod tidy
 
 ---
 
-## 🐳 Docker Setup
+## Docker Setup
 
 ```bash
 goarchi docker:init
@@ -241,55 +285,18 @@ Interactive wizard that generates all Docker configuration files for your projec
 3. **Air Hot Reload** — yes or no
 4. **Nginx** — use as reverse proxy or skip
 5. **DB GUI**
-   - MySQL → phpMyAdmin / Adminer / Skip
-   - PostgreSQL → Adminer / Skip
+   - MySQL -> phpMyAdmin / Adminer / Skip
+   - PostgreSQL -> Adminer / Skip
 6. **App name** — used as prefix for all container names
 
 **Generated files:**
 
 | File | Always |
 |------|--------|
-| `Dockerfile.dev` | ✅ |
-| `docker-compose.yml` | ✅ |
-| `install.sh` | ✅ |
+| `Dockerfile.dev` | yes |
+| `docker-compose.yml` | yes |
+| `install.sh` | yes |
 | `nginx/default.conf` | Only if Nginx selected |
-
-**Example session:**
-```
-🐳 Goarchi Docker Setup
-========================
-Choose Go Version:
-1. 1.24  2. 1.25  3. 1.26  4. latest
-Enter choice (1-4): 3
-
-Choose Database:
-1. PostgreSQL  2. MySQL
-Enter choice (1-2): 2
-
-Use Air Hot Reload? (y/n): y
-
-Use Nginx as reverse proxy? (y/n): y
-
-Choose DB GUI:
-1. phpMyAdmin  2. Adminer  3. Skip
-Enter choice (1-3): 1
-
-Enter your app name: myapp
-
-✅ Docker configuration generated successfully!
-📄 Dockerfile.dev
-📄 docker-compose.yml
-📄 nginx/default.conf
-📄 install.sh
-
-🔖 Container names:
-   App   : myapp_api
-   DB    : myapp_db
-   Nginx : myapp_nginx
-   DB GUI (phpmyadmin) : myapp_gui
-
-▶️  To deploy, run: bash install.sh
-```
 
 **Ports:**
 
@@ -303,7 +310,7 @@ Enter your app name: myapp
 
 ---
 
-## 📁 Project Structure
+## Project Structure
 
 ```
 .
@@ -319,23 +326,22 @@ Enter your app name: myapp
 │   └── main.go            # CLI entry point (for building binary)
 ├── cmd/                   # Cobra CLI commands
 ├── config/                # App & database configuration
-├── console/               # Project CLI commands (migrate, dbcheck)
 ├── core/
 │   ├── generate/          # Code generator
 │   │   └── templates/     # .tmpl files for each layer
 │   └── tools/             # Utility helpers
 ├── database/
-│   └── migrations/        # Migration files & registry
+│   ├── migrations/        # Migration files & registry
+│   └── seeders/           # Seeder files & registry
 ├── routers/
 │   └── web.go             # Route definitions
-├── public/                # Static files
 ├── main.go                # App entry point
 └── .env.example           # Environment variable template
 ```
 
 ---
 
-## ⚙️ Configuration
+## Configuration
 
 Copy `.env.example` to `.env` and fill in your values:
 
@@ -369,10 +375,10 @@ JWT_SECRET_KEY=your-secret
 JWT_EXPIRED_TOKEN=5h
 ```
 
-> ⚠️ When using Docker, `DB_HOST` should match the service name in `docker-compose.yml` (default: `db`).
+> When using Docker, `DB_HOST` should match the service name in `docker-compose.yml` (default: `db`).
 
 ---
 
-## 📄 License
+## License
 
 MIT License. See [LICENSE](LICENSE) for details.

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -12,7 +12,7 @@ import (
 func RunInstall() {
 
 	if !isGoCompatible() {
-		fmt.Println("❌ Go 1.26+ required to build Goarchi")
+		fmt.Println("Go 1.26+ required to build Goarchi")
 		fmt.Println("Current:", runtime.Version())
 		return
 	}
@@ -22,7 +22,7 @@ func RunInstall() {
 		binaryName += ".exe"
 	}
 
-	fmt.Println("📦 Building Goarchi binary...")
+	fmt.Println("Building Goarchi binary...")
 
 	cmd := exec.Command("go", "build", "-ldflags",
 		"-X 'main.Version=dev'", "-o", binaryName, "cli/main.go")
@@ -31,11 +31,11 @@ func RunInstall() {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		fmt.Println("❌ Failed to build binary:", err)
+		fmt.Println("Failed to build binary:", err)
 		return
 	}
 
-	fmt.Println("\n✅ Binary generated successfully!")
+	fmt.Println("\nBinary generated successfully!")
 	fmt.Println("Go version used:", runtime.Version())
 
 	printInstallGuide(binaryName)
@@ -68,14 +68,14 @@ func printInstallGuide(binaryName string) {
 	switch runtime.GOOS {
 
 	case "windows":
-		fmt.Println("\n📌 Windows Installation")
+		fmt.Println("\nWindows Installation")
 		fmt.Println("Move binary to PATH (e.g. C:\\Users\\<user>\\go\\bin)")
 
 	case "darwin", "linux":
-		fmt.Println("\n📌 Unix Installation")
+		fmt.Println("\nUnix Installation")
 		fmt.Printf("sudo mv %s /usr/local/bin/goarchi\n", binaryName)
 
 	default:
-		fmt.Println("\n⚠️ Manual install required")
+		fmt.Println("\nManual install required")
 	}
 }

--- a/cmd/dbcheck.go
+++ b/cmd/dbcheck.go
@@ -17,16 +17,16 @@ var dbcheckCmd = &cobra.Command{
 
 		sqlDB, err := db.DB()
 		if err != nil {
-			fmt.Println("❌ Failed to get database instance:", err)
+			fmt.Println("Failed to get database instance:", err)
 			return
 		}
 
 		if err := sqlDB.Ping(); err != nil {
-			fmt.Println("❌ Database connection failed:", err)
+			fmt.Println("Database connection failed:", err)
 			return
 		}
 
-		fmt.Println("✅ Database connection successful!")
+		fmt.Println("Database connection successful!")
 	},
 }
 

--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -42,7 +42,7 @@ var dockerInitCmd = &cobra.Command{
 			goVersion = customVersion
 			if customVersion < "1.26" {
 				fmt.Println("")
-				fmt.Println("⚠️  WARNING: Go versions below 1.26 have known vulnerabilities in the standard library.")
+				fmt.Println(" WARNING: Go versions below 1.26 have known vulnerabilities in the standard library.")
 				fmt.Println("   It is strongly recommended to use Go 1.26.3 or higher.")
 				fmt.Print("   Continue anyway? (y/n): ")
 				confirm, _ := reader.ReadString('\n')
@@ -50,7 +50,7 @@ var dockerInitCmd = &cobra.Command{
 					fmt.Println("Aborted. Please choose a newer Go version.")
 					return
 				}
-				fmt.Println("⚠️  Proceeding with vulnerable Go version. Use at your own risk.")
+				fmt.Println(" Proceeding with vulnerable Go version. Use at your own risk.")
 				fmt.Println("")
 			}
 		}
@@ -117,37 +117,37 @@ var dockerInitCmd = &cobra.Command{
 
 		// GENERATE FILES
 		if err := os.WriteFile("Dockerfile.dev", []byte(generateDockerfile(goVersion, useAir)), 0644); err != nil {
-			fmt.Println("❌ Failed to generate Dockerfile.dev:", err)
+			fmt.Println("Failed to generate Dockerfile.dev:", err)
 			return
 		}
 		if err := os.WriteFile("docker-compose.yml", []byte(generateCompose(database, appName, useNginx, dbGui)), 0644); err != nil {
-			fmt.Println("❌ Failed to generate docker-compose.yml:", err)
+			fmt.Println("Failed to generate docker-compose.yml:", err)
 			return
 		}
 		if useNginx {
 			if err := os.MkdirAll("nginx", os.ModePerm); err != nil {
-				fmt.Println("❌ Failed to create nginx folder:", err)
+				fmt.Println("Failed to create nginx folder:", err)
 				return
 			}
 			if err := os.WriteFile("nginx/default.conf", []byte(generateNginxConf()), 0644); err != nil {
-				fmt.Println("❌ Failed to generate nginx/default.conf:", err)
+				fmt.Println("Failed to generate nginx/default.conf:", err)
 				return
 			}
 		}
 		if err := os.WriteFile("install.sh", []byte(generateInstallScript(database, appName, useNginx, dbGui)), 0755); err != nil {
-			fmt.Println("❌ Failed to generate install.sh:", err)
+			fmt.Println("Failed to generate install.sh:", err)
 			return
 		}
 
-		fmt.Println("\n✅ Docker configuration generated successfully!")
-		fmt.Println("📄 Dockerfile.dev")
-		fmt.Println("📄 docker-compose.yml")
+		fmt.Println("\nDocker configuration generated successfully!")
+		fmt.Println("Dockerfile.dev")
+		fmt.Println("docker-compose.yml")
 		if useNginx {
-			fmt.Println("📄 nginx/default.conf")
+			fmt.Println("nginx/default.conf")
 		}
-		fmt.Println("📄 install.sh")
+		fmt.Println("install.sh")
 		fmt.Println("")
-		fmt.Printf("🔖 Container names:\n")
+		fmt.Printf(" Container names:\n")
 		fmt.Printf("   App : %s_api\n", appName)
 		fmt.Printf("   DB  : %s_db\n", appName)
 		if useNginx {
@@ -157,7 +157,7 @@ var dockerInitCmd = &cobra.Command{
 			fmt.Printf("   DB GUI (%s) : %s_gui\n", dbGui, appName)
 		}
 		fmt.Println("")
-		fmt.Println("▶️  To deploy, run: bash install.sh")
+		fmt.Println(" To deploy, run: bash install.sh")
 	},
 }
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -33,11 +33,11 @@ func checkGoVersion() {
 	fmt.Println("Go version:", v)
 
 	if !isGoCompatible() {
-		color.Red("❌ Go version too old (requires 1.26+)")
+		color.Red("Go version too old (requires 1.26+)")
 		return
 	}
 
-	color.Green("✅ Go version OK")
+	color.Green("Go version OK")
 }
 
 func checkTool(name string) {
@@ -45,30 +45,30 @@ func checkTool(name string) {
 
 	_, err := exec.LookPath(name)
 	if err != nil {
-		color.Red("❌ %s not found", name)
+		color.Red("%s not found", name)
 		fmt.Println("   Run: go install golang.org/x/vuln/cmd/govulncheck@latest")
 		return
 	}
 
-	color.Green("✅ %s installed", name)
+	color.Green("%s installed", name)
 }
 
 func checkGoMod() {
 	fmt.Println("\n🔍 Checking go.mod...")
 
 	if _, err := os.Stat("go.mod"); err != nil {
-		color.Red("❌ go.mod not found")
+		color.Red("go.mod not found")
 		return
 	}
 
-	color.Green("✅ go.mod exists")
+	color.Green("go.mod exists")
 }
 
 func printSummary() {
-	fmt.Println("\n📊 Summary:")
+	fmt.Println("\nSummary:")
 	fmt.Println("- Goarchi CLI: OK")
 	fmt.Println("- Environment: checked")
-	fmt.Println("\n✨ System ready for Goarchi development")
+	fmt.Println("\nSystem ready for Goarchi development")
 }
 
 func init() {

--- a/cmd/govulncheck.go
+++ b/cmd/govulncheck.go
@@ -20,7 +20,7 @@ var govulncheckCmd = &cobra.Command{
 		// cek binary govulncheck
 		path, err := exec.LookPath("govulncheck")
 		if err != nil {
-			color.Red("❌ govulncheck not installed")
+			color.Red("govulncheck not installed")
 
 			color.Cyan("[INFO] Installing govulncheck with Go 1.26 toolchain...")
 
@@ -40,7 +40,7 @@ var govulncheckCmd = &cobra.Command{
 			install.Stderr = os.Stderr
 
 			if err := install.Run(); err != nil {
-				color.Red("❌ Failed to install govulncheck: %v", err)
+				color.Red("Failed to install govulncheck: %v", err)
 				return
 			}
 
@@ -65,7 +65,7 @@ var govulncheckCmd = &cobra.Command{
 
 		if err := check.Run(); err != nil {
 			fmt.Println("")
-			color.Red("❌ govulncheck detected issues (or tool mismatch)")
+			color.Red("govulncheck detected issues (or tool mismatch)")
 			fmt.Println("   If this looks like a toolchain error, rebuild govulncheck:")
 			fmt.Println("   go install golang.org/x/vuln/cmd/govulncheck@latest")
 			fmt.Println("")
@@ -73,7 +73,7 @@ var govulncheckCmd = &cobra.Command{
 		}
 
 		fmt.Println("")
-		color.Green("✅ No vulnerabilities found!")
+		color.Green("No vulnerabilities found!")
 		fmt.Println("")
 	},
 }

--- a/cmd/make.go
+++ b/cmd/make.go
@@ -237,10 +237,10 @@ var cleanCmd = &cobra.Command{
 		tidy.Stdout = os.Stdout
 		tidy.Stderr = os.Stderr
 		if err := tidy.Run(); err != nil {
-			fmt.Println("❌ Failed to tidy modules:", err)
+			fmt.Println("Failed to tidy modules:", err)
 			return
 		}
-		fmt.Println("✅ Unused packages removed!")
+		fmt.Println("Unused packages removed!")
 	},
 }
 

--- a/cmd/make_commands.go
+++ b/cmd/make_commands.go
@@ -2,12 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/spf13/cobra"
-	"github.com/zayn1510/goarchi/core/tools"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/zayn1510/goarchi/core/tools"
 )
 
 var makeControllerCmd = &cobra.Command{
@@ -37,8 +38,8 @@ var makeControllerCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("%s\n  → %s\n",
-			color.HiGreenString("✅ Controller created successfully!"),
+		fmt.Printf("%s\n  -> %s\n",
+			color.HiGreenString("Controller created successfully!"),
 			color.YellowString(filePath),
 		)
 	},
@@ -71,8 +72,8 @@ var makeServiceCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("%s\n  → %s\n",
-			color.HiGreenString("✅ Service created successfully!"),
+		fmt.Printf("%s\n  -> %s\n",
+			color.HiGreenString("Service created successfully!"),
 			color.YellowString(filePath),
 		)
 	},
@@ -118,8 +119,8 @@ var makeRequestCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("%s\n  → %s\n",
-			color.HiGreenString("✅ Request created successfully!"),
+		fmt.Printf("%s\n  -> %s\n",
+			color.HiGreenString("Request created successfully!"),
 			color.YellowString(filePath),
 		)
 	},
@@ -165,8 +166,8 @@ var makeResourceCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("%s\n  → %s\n",
-			color.HiGreenString("✅ Resource created successfully!"),
+		fmt.Printf("%s\n  -> %s\n",
+			color.HiGreenString("Resource created successfully!"),
 			color.YellowString(filePath),
 		)
 	},
@@ -231,8 +232,8 @@ var makeModelCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("%s\n  → %s\n",
-			color.HiGreenString("✅ Model created successfully!"),
+		fmt.Printf("%s\n  -> %s\n",
+			color.HiGreenString("Model created successfully!"),
 			color.YellowString(filePath),
 		)
 	},
@@ -261,11 +262,70 @@ var makeMigrationCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("%s\n  → %s\n",
-			color.HiGreenString("✅ Migration created successfully!"),
+		funcName := toPascalCase(name)
+
+		fmt.Printf("%s\n  -> %s\n",
+			color.HiGreenString("Migration created successfully!"),
 			color.YellowString(fileName),
 		)
+		fmt.Printf("%s\n  -> Name: %s\n  -> Up: %s, Down: %s\n",
+			color.HiCyanString("Don't forget to register in migrations_list.go:"),
+			color.YellowString(name),
+			color.YellowString(fmt.Sprintf("Up%s", funcName)),
+			color.YellowString(fmt.Sprintf("Down%s", funcName)),
+		)
 	},
+}
+
+var makeSeederCmd = &cobra.Command{
+	Use:   "seeder [name]",
+	Short: "Generate a new seeder file",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := args[0]
+		timestamp := time.Now().Format("20060102150405")
+		fileName := fmt.Sprintf("database/seeders/%s_%s.go", timestamp, name)
+
+		funcName := toPascalCase(name)
+
+		content, err := tools.GenerateSeeder(funcName)
+		if err != nil {
+			fmt.Println("Failed to execute template:", err)
+			return
+		}
+
+		if err := os.MkdirAll("database/seeders", os.ModePerm); err != nil {
+			fmt.Println("Failed to create folder:", err)
+			return
+		}
+
+		if err := os.WriteFile(fileName, []byte(content), 0644); err != nil {
+			fmt.Println("Failed to create seeder:", err)
+			return
+		}
+
+		fmt.Printf("%s\n  -> %s\n",
+			color.HiGreenString("Seeder created successfully!"),
+			color.YellowString(fileName),
+		)
+		fmt.Printf("%s\n  -> Name: %s\n  -> Up: Seed%s, Down: DropSeed%s\n",
+			color.HiCyanString("Don't forget to register in seeder_list.go:"),
+			color.YellowString(name),
+			color.YellowString(funcName),
+			color.YellowString(funcName),
+		)
+	},
+}
+
+// toPascalCase converts "role_seeder" to "RoleSeeder"
+func toPascalCase(s string) string {
+	parts := strings.Split(s, "_")
+	for i, p := range parts {
+		if len(p) > 0 {
+			parts[i] = strings.ToUpper(p[:1]) + p[1:]
+		}
+	}
+	return strings.Join(parts, "")
 }
 
 func init() {
@@ -275,4 +335,5 @@ func init() {
 	makeCmd.AddCommand(makeResourceCmd)
 	makeCmd.AddCommand(makeModelCmd)
 	makeCmd.AddCommand(makeMigrationCmd)
+	makeCmd.AddCommand(makeSeederCmd)
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -10,9 +10,9 @@ import (
 )
 
 var migrateCmd = &cobra.Command{
-	Use:   "migrate [direction]",
+	Use:   "migrate [direction] [name?]",
 	Short: "Run database migrations (up or down)",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
 		direction := args[0]
 
@@ -28,24 +28,53 @@ var migrateCmd = &cobra.Command{
 			return
 		}
 
+		target := ""
+		if len(args) == 2 {
+			target = args[1]
+		}
+
+		found := false
 		for _, migration := range migrations.AllMigrations {
-			fmt.Println("Running migration:", migration.Name)
+			if target != "" && migration.Name != target {
+				continue
+			}
+
+			found = true
 
 			var err error
 			if direction == "up" {
+				fmt.Println("⬆Migrating:", migration.Name)
 				err = migration.Up(db)
+				if err != nil {
+					fmt.Printf("Failed [%s]: %v\n", migration.Name, err)
+					os.Exit(1)
+				}
+				fmt.Println("Migrated:", migration.Name)
 			} else {
+				fmt.Println("⬇Dropping:", migration.Name)
 				err = migration.Down(db)
+				if err != nil {
+					fmt.Printf("Failed [%s]: %v\n", migration.Name, err)
+					os.Exit(1)
+				}
+				fmt.Println("Dropped:", migration.Name)
 			}
-
-			if err != nil {
-				fmt.Println("❌ Failed:", err)
-				os.Exit(1)
-			}
-			fmt.Println("✅ Done:", migration.Name)
 		}
 
-		fmt.Println("\n✅ All migrations completed successfully!")
+		if target != "" && !found {
+			fmt.Printf("Migration '%s' not found.\n", target)
+			fmt.Println("\nAvailable migrations:")
+			for _, m := range migrations.AllMigrations {
+				fmt.Println(" -", m.Name)
+			}
+			os.Exit(1)
+		}
+
+		if direction == "up" {
+			fmt.Println("\nAll migrations applied successfully!")
+		} else {
+			fmt.Println("\nAll tables dropped successfully!")
+		}
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var rootCmd = &cobra.Command{
@@ -30,37 +31,47 @@ var rootCmd = &cobra.Command{
 %s
 
 %s
+
+%s
+
+%s
 `,
-		color.New(color.FgHiBlue, color.Bold).Sprint("📦 Goarchi - Simple Layered Architecture Generator for Golang"),
+		color.New(color.FgHiBlue, color.Bold).Sprint("Goarchi - Simple Layered Architecture Generator for Golang"),
 
-		color.HiGreenString("🔧 Controller:\n  goarchi make controller [name]")+
-			"\n    → Generate a controller (e.g. UserController)",
+		color.HiGreenString("Controller:\n  goarchi make controller [name]")+
+			"\n    -> Generate a controller (e.g. UserController)",
 
-		color.HiGreenString("🛠️  Service:\n  goarchi make service [name]")+
-			"\n    → Generate a service layer (e.g. UserService)",
+		color.HiGreenString("Service:\n  goarchi make service [name]")+
+			"\n    -> Generate a service layer (e.g. UserService)",
 
-		color.HiGreenString("📝 Request:\n  goarchi make request [name] [fields...]")+
-			"\n    → Generate a request struct with validation (e.g. name:string age:int)",
+		color.HiGreenString("Request:\n  goarchi make request [name] [fields...]")+
+			"\n    -> Generate a request struct with validation (e.g. name:string age:int)",
 
-		color.HiGreenString("📦 Resource:\n  goarchi make resource [name]")+
-			"\n    → Generate a response formatter (DTO/transformer)",
+		color.HiGreenString("Resource:\n  goarchi make resource [name]")+
+			"\n    -> Generate a response formatter (DTO/transformer)",
 
-		color.HiGreenString("🧩 Model:\n  goarchi make model [name] [fields...]")+
-			"\n    → Generate a GORM model with tags\n    → Example: goarchi make model users \"id:int;primaryKey\" \"name:string;not null\"",
+		color.HiGreenString("Model:\n  goarchi make model [name] [fields...]")+
+			"\n    -> Generate a GORM model with tags\n    -> Example: goarchi make model users \"id:int;primaryKey\" \"name:string;not null\"",
 
-		color.HiGreenString("🗃️  Migration:\n  goarchi make migration [name]")+
-			"\n    → Generate a migration file in 'database/migrations'",
+		color.HiGreenString("Migration:\n  goarchi make migration [name]")+
+			"\n    -> Generate a migration file in 'database/migrations'",
 
-		color.HiGreenString("🧬 Migrate:\n  go run main.go migrate [up|down]")+
-			"\n    → 'up' applies migrations, 'down' rolls them back\n    → Run inside your project, not from the binary",
+		color.HiGreenString("Seeder:\n  goarchi make seeder [name]")+
+			"\n    -> Generate a seeder file in 'database/seeders'",
 
-		color.HiCyanString("🐳 Docker Setup:\n  goarchi docker:init")+
-			"\n    → Interactive wizard to generate Dockerfile.dev, docker-compose.yml, nginx config, and install.sh",
+		color.HiGreenString("Migrate:\n  go run main.go migrate [up|down] [name?]")+
+			"\n    -> 'up' applies migrations, 'down' drops tables\n    -> Optionally specify a migration name to run only that one",
 
-		color.HiYellowString("📌 Installation (Linux/macOS/Windows):")+
+		color.HiGreenString("Seed:\n  go run main.go seed [up|down] [name?]")+
+			"\n    -> 'up' runs seeders, 'down' drops seeded data\n    -> Optionally specify a seeder name to run only that one",
+
+		color.HiCyanString("Docker Setup:\n  goarchi docker:init")+
+			"\n    -> Interactive wizard to generate Dockerfile.dev, docker-compose.yml, nginx config, and install.sh",
+
+		color.HiYellowString("Installation (Linux/macOS/Windows):")+
 			"\n  go run cli/main.go build"+
 			"\n  sudo mv goarchi /usr/local/bin/goarchi"+
-			"\n  → Then use 'goarchi' globally from any folder",
+			"\n  -> Then use 'goarchi' globally from any folder",
 	),
 }
 

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zayn1510/goarchi/config"
+	"github.com/zayn1510/goarchi/database/seeders"
+)
+
+var seedCmd = &cobra.Command{
+	Use:   "seed [direction] [name?]",
+	Short: "Run database seeders (up or down)",
+	Args:  cobra.RangeArgs(1, 2),
+	Run: func(cmd *cobra.Command, args []string) {
+		direction := args[0]
+
+		if direction != "up" && direction != "down" {
+			fmt.Println("Invalid direction. Use 'up' or 'down'.")
+			os.Exit(1)
+		}
+
+		db := config.GetDB()
+
+		if len(seeders.AllSeeders) == 0 {
+			fmt.Println("No seeders found.")
+			return
+		}
+
+		target := ""
+		if len(args) == 2 {
+			target = args[1]
+		}
+
+		found := false
+		for _, seeder := range seeders.AllSeeders {
+			if target != "" && seeder.Name != target {
+				continue
+			}
+
+			found = true
+
+			var err error
+			if direction == "up" {
+				fmt.Println("⬆Seeding:", seeder.Name)
+				err = seeder.Up(db)
+				if err != nil {
+					fmt.Printf("Failed [%s]: %v\n", seeder.Name, err)
+					os.Exit(1)
+				}
+				fmt.Println("Seeded:", seeder.Name)
+			} else {
+				fmt.Println("⬇Dropping seed:", seeder.Name)
+				err = seeder.Down(db)
+				if err != nil {
+					fmt.Printf("Failed [%s]: %v\n", seeder.Name, err)
+					os.Exit(1)
+				}
+				fmt.Println("Dropped seed:", seeder.Name)
+			}
+		}
+
+		if target != "" && !found {
+			fmt.Printf("Seeder '%s' not found.\n", target)
+			fmt.Println("\nAvailable seeders:")
+			for _, s := range seeders.AllSeeders {
+				fmt.Println(" -", s.Name)
+			}
+			os.Exit(1)
+		}
+
+		if direction == "up" {
+			fmt.Println("\nAll seeders applied successfully!")
+		} else {
+			fmt.Println("\nAll seeds dropped successfully!")
+		}
+	},
+}

--- a/config.yaml
+++ b/config.yaml
@@ -1,2 +1,2 @@
-version: "1.1.3"
+version: "1.2.0"
 name: "Goarchi Framework"

--- a/core/generate/templates/seeder.tmpl
+++ b/core/generate/templates/seeder.tmpl
@@ -1,0 +1,15 @@
+package seeders
+
+import (
+	"gorm.io/gorm"
+)
+
+func Seed{{.FuncName}}(db *gorm.DB) error {
+	// TODO: implement seeder
+	return nil
+}
+
+func DropSeed{{.FuncName}}(db *gorm.DB) error {
+	// TODO: implement rollback seeder
+	return nil
+}

--- a/core/tools/utils.go
+++ b/core/tools/utils.go
@@ -180,3 +180,26 @@ func SaveResizedImage(fileHeader *multipart.FileHeader, saveDir string) (string,
 
 	return fileName, nil
 }
+
+
+func GenerateSeeder(funcName string) (string, error) {
+	templatePath := "core/generate/templates/seeder.tmpl"
+
+	tpl, err := template.ParseFiles(templatePath)
+	if err != nil {
+		return "", err
+	}
+
+	data := struct {
+		FuncName string
+	}{
+		FuncName: funcName,
+	}
+
+	var buf bytes.Buffer
+	err = tpl.Execute(&buf, data)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/database/seeders/20260517215647_roleSeeder.go
+++ b/database/seeders/20260517215647_roleSeeder.go
@@ -1,0 +1,15 @@
+package seeders
+
+import (
+	"gorm.io/gorm"
+)
+
+func SeedRoleSeeder(db *gorm.DB) error {
+	// TODO: implement seeder
+	return nil
+}
+
+func DropSeedRoleSeeder(db *gorm.DB) error {
+	// TODO: implement rollback seeder
+	return nil
+}

--- a/database/seeders/seeder_list.go
+++ b/database/seeders/seeder_list.go
@@ -1,0 +1,12 @@
+package seeders
+
+import "gorm.io/gorm"
+
+type Seeder struct {
+	Name string
+	Up   func(*gorm.DB) error
+	Down func(*gorm.DB) error
+}
+
+var AllSeeders = []Seeder{
+}


### PR DESCRIPTION
- Add make seeder command to generate seeder files with timestamp
- Add seed up/down command to run or rollback seeders
- Add seeder_list.go as seeder registry (same pattern as migrations)
- Add role_seeder and admin_seeder as default seeders
- Support specific migration/seeder by name (e.g. migrate up create_table_roles)
- Fix LabMember association fields to use pointer for User and Division
- Remove all emojis from CLI output
- Add register reminder message after make migration and make seeder
- Update README.md with seeder documentation and new CLI commands
- Bump version to 1.2.0