### PR TITLE
fix: code quality improvements and add CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Build
         run: go build ./...
 
+      - name: Check go mod tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
       - name: Doctor check
         run: go run cli/main.go doctor
 
@@ -35,3 +40,9 @@ jobs:
         env:
           GOTOOLCHAIN: local
           CGO_ENABLED: "1"
+
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
+      - name: Run golangci-lint
+        run: golangci-lint run ./...

--- a/app/middleware/jwt.go
+++ b/app/middleware/jwt.go
@@ -1,16 +1,16 @@
 package middleware
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/zayn1510/goarchi/config"
+	"fmt"
 )
 
 const (
@@ -26,17 +26,7 @@ var secretKey = []byte(os.Getenv("JWT_SECRET_KEY"))
 func GetExpiredDuration() time.Duration {
 	return config.JWTExpired
 }
-func getEnv(key, defaultValue string) int {
-	val, exists := os.LookupEnv(key)
-	if !exists {
-		val = defaultValue
-	}
-	result, err := strconv.Atoi(val)
-	if err != nil {
-		return 5
-	}
-	return result
-}
+
 func validateToken(tokenString string) (*jwt.Token, jwt.MapClaims, error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -46,17 +36,17 @@ func validateToken(tokenString string) (*jwt.Token, jwt.MapClaims, error) {
 	})
 
 	if err != nil || !token.Valid {
-		return nil, nil, fmt.Errorf(ErrInvalidToken)
+		return nil, nil, errors.New(ErrInvalidToken)
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		return nil, nil, fmt.Errorf(ErrInvalidClaims)
+		return nil, nil, errors.New(ErrInvalidClaims)
 	}
 
 	if exp, ok := claims["exp"].(float64); ok {
 		if time.Now().Unix() > int64(exp) {
-			return nil, nil, fmt.Errorf(ErrTokenExpired)
+			return nil, nil, errors.New(ErrTokenExpired)
 		}
 	}
 

--- a/app/middleware/validator.go
+++ b/app/middleware/validator.go
@@ -22,14 +22,15 @@ var (
 )
 
 func init() {
-	// Inisialisasi translator
 	eng := en.New()
 	uni := ut.New(eng, eng)
 
 	trans, _ := uni.GetTranslator("en")
 	validate = validator.New()
 
-	enTranslations.RegisterDefaultTranslations(validate, trans)
+	if err := enTranslations.RegisterDefaultTranslations(validate, trans); err != nil {
+		panic(fmt.Sprintf("failed to register translations: %v", err))
+	}
 
 	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
 		name := fld.Tag.Get("json")

--- a/cmd/make.go
+++ b/cmd/make.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+	"os"
 )
 
 type AppConfig struct {
@@ -59,7 +59,6 @@ var installDBCommand = &cobra.Command{
 
 		reader := bufio.NewReader(os.Stdin)
 
-		// Select client
 		var choice int
 		for {
 			fmt.Println("Choose a database client to install:")
@@ -75,21 +74,19 @@ var installDBCommand = &cobra.Command{
 				choice = num
 				break
 			}
-			fmt.Println("❌ Invalid choice. Please enter a number between 1 and 4.\n")
+			fmt.Println("Invalid choice. Please enter a number between 1 and 4.")
 		}
 
-		// Handle GORM special case
 		if choice == 1 {
-			fmt.Println("📦 Installing GORM core (gorm.io/gorm)...")
+			fmt.Println("Installing GORM core (gorm.io/gorm)...")
 			cmdGorm := exec.Command("go", "get", "gorm.io/gorm")
 			cmdGorm.Stdout = os.Stdout
 			cmdGorm.Stderr = os.Stderr
 			if err := cmdGorm.Run(); err != nil {
-				fmt.Println("❌ Failed to install GORM:", err)
+				fmt.Println("Failed to install GORM:", err)
 				return
 			}
 
-			// Driver selection for GORM
 			fmt.Println("Choose GORM driver to install:")
 			drivers := map[int]string{
 				1: "gorm.io/driver/mysql",
@@ -118,33 +115,32 @@ var installDBCommand = &cobra.Command{
 					driverChoice = num
 					break
 				}
-				fmt.Println("❌ Invalid driver. Please enter a valid number.\n")
+				fmt.Println("Invalid driver. Please enter a valid number.")
 			}
 
 			driver := drivers[driverChoice]
-			fmt.Printf("📦 Installing GORM driver: %s\n", driver)
+			fmt.Printf("Installing GORM driver: %s\n", driver)
 			cmdDriver := exec.Command("go", "get", driver)
 			cmdDriver.Stdout = os.Stdout
 			cmdDriver.Stderr = os.Stderr
 			if err := cmdDriver.Run(); err != nil {
-				fmt.Printf("❌ Failed to install %s: %s\n", driver, err)
+				fmt.Printf("Failed to install %s: %s\n", driver, err)
 			} else {
-				fmt.Printf("✅ Successfully installed %s\n", driver)
+				fmt.Printf("Successfully installed %s\n", driver)
 			}
 			return
 		}
 
-		// Install non-GORM package
 		packagePath := packages[choice]
-		fmt.Printf("📦 Installing %s ...\n", packagePath)
+		fmt.Printf("Installing %s ...\n", packagePath)
 		cmdInstall := exec.Command("go", "get", packagePath)
 		cmdInstall.Stdout = os.Stdout
 		cmdInstall.Stderr = os.Stderr
 
 		if err := cmdInstall.Run(); err != nil {
-			fmt.Printf("❌ Failed to install %s: %s\n", packagePath, err)
+			fmt.Printf("Failed to install %s: %s\n", packagePath, err)
 		} else {
-			fmt.Printf("✅ Successfully installed %s\n", packagePath)
+			fmt.Printf("Successfully installed %s\n", packagePath)
 		}
 	},
 }
@@ -173,15 +169,7 @@ Simply select a framework by entering the corresponding number.`,
 			3: "github.com/labstack/echo/v4",
 		}
 
-		fmt.Println("Choose a framework to install:")
-		for i, opt := range options {
-			fmt.Printf("  %d. %s\n", i+1, opt)
-		}
-		fmt.Print("\nEnter your choice (1-3): ")
-
 		reader := bufio.NewReader(os.Stdin)
-		input, _ := reader.ReadString('\n')
-		input = strings.TrimSpace(input)
 		var choice int
 		for {
 			fmt.Println("Choose a framework to install:")
@@ -198,19 +186,19 @@ Simply select a framework by entering the corresponding number.`,
 				choice = num
 				break
 			}
-			fmt.Println("❌ Invalid choice. Please enter a number between 1 and 3.\n")
+			fmt.Println("Invalid choice. Please enter a number between 1 and 3.")
 		}
 		packagePath := packages[choice]
-		fmt.Printf("📦 Installing %s ...\n", packagePath)
+		fmt.Printf("Installing %s ...\n", packagePath)
 
 		cmdInstall := exec.Command("go", "get", packagePath)
 		cmdInstall.Stdout = os.Stdout
 		cmdInstall.Stderr = os.Stderr
 
 		if err := cmdInstall.Run(); err != nil {
-			fmt.Printf("❌ Failed to install %s: %s\n", packagePath, err)
+			fmt.Printf("Failed to install %s: %s\n", packagePath, err)
 		} else {
-			fmt.Printf("✅ Successfully installed %s\n", packagePath)
+			fmt.Printf("Successfully installed %s\n", packagePath)
 		}
 	},
 }
@@ -218,17 +206,17 @@ Simply select a framework by entering the corresponding number.`,
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show the current version of the Goarchi Framework CLI tool",
-	Long:  `Displays the current version of the Goarchi Framework CLI tool as defined in the configuration file. This command helps you keep track of the version you are using and check for any updates or new releases.`,
+	Long:  `Displays the current version of the Goarchi Framework CLI tool as defined in the configuration file.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		config, err := readConfig("config.yaml")
 		if err != nil {
 			fmt.Println("Error reading config:", err)
 			return
 		}
-		// Displaying version
 		fmt.Printf("Goarchi Framework CLI Tool - Version: %s\n", config.Version)
 	},
 }
+
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
 	Short: "Clean unused Go modules",
@@ -245,13 +233,11 @@ var cleanCmd = &cobra.Command{
 }
 
 func readConfig(filename string) (*AppConfig, error) {
-	// Membaca isi file YAML
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	// Parsing YAML
 	var config AppConfig
 	err = yaml.Unmarshal(data, &config)
 	if err != nil {

--- a/cmd/make_commands.go
+++ b/cmd/make_commands.go
@@ -9,7 +9,11 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/zayn1510/goarchi/core/tools"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
+
+var caser = cases.Title(language.English)
 
 var makeControllerCmd = &cobra.Command{
 	Use:   "controller [name]",
@@ -20,7 +24,7 @@ var makeControllerCmd = &cobra.Command{
 		parts := strings.Split(path, "/")
 		name := parts[len(parts)-1]
 
-		structName := strings.Title(name) + "Controller"
+		structName := caser.String(name) + "Controller"
 		filePath := fmt.Sprintf("app/controllers/%s_controller.go", path)
 		buf, err := tools.GenerateController(structName)
 		if err != nil {
@@ -54,7 +58,7 @@ var makeServiceCmd = &cobra.Command{
 		parts := strings.Split(path, "/")
 		name := parts[len(parts)-1]
 
-		structName := strings.Title(name) + "Service"
+		structName := caser.String(name) + "Service"
 		filePath := fmt.Sprintf("app/services/%s_service.go", path)
 		content, err := tools.GenerateServices(structName)
 		if err != nil {
@@ -88,7 +92,7 @@ var makeRequestCmd = &cobra.Command{
 		parts := strings.Split(path, "/")
 		name := parts[len(parts)-1]
 
-		structName := strings.Title(name) + "Request"
+		structName := caser.String(name) + "Request"
 		filePath := fmt.Sprintf("app/requests/%s_request.go", path)
 
 		var fieldsBuilder strings.Builder
@@ -98,7 +102,7 @@ var makeRequestCmd = &cobra.Command{
 				fmt.Printf("Invalid field '%s'. Use format name:type\n", fieldArg)
 				return
 			}
-			fieldName := strings.Title(parts[0])
+			fieldName := caser.String(parts[0])
 			fieldType := parts[1]
 			fieldsBuilder.WriteString(fmt.Sprintf("\t%s %s `json:\"%s\" validate:\"required\"`\n", fieldName, fieldType, parts[0]))
 		}
@@ -135,7 +139,7 @@ var makeResourceCmd = &cobra.Command{
 		parts := strings.Split(path, "/")
 		name := parts[len(parts)-1]
 
-		structName := strings.Title(name) + "Resource"
+		structName := caser.String(name) + "Resource"
 		filePath := fmt.Sprintf("app/resources/%s_resource.go", path)
 
 		var fieldsBuilder strings.Builder
@@ -145,7 +149,7 @@ var makeResourceCmd = &cobra.Command{
 				fmt.Printf("Invalid field '%s'. Use format name:type\n", fieldArg)
 				return
 			}
-			fieldName := strings.Title(parts[0])
+			fieldName := caser.String(parts[0])
 			fieldType := parts[1]
 			fieldsBuilder.WriteString(fmt.Sprintf("\t%s %s `json:\"%s\"`\n", fieldName, fieldType, parts[0]))
 		}
@@ -181,7 +185,7 @@ var makeModelCmd = &cobra.Command{
 		path := strings.ToLower(args[0])
 		parts := strings.Split(path, "/")
 		name := parts[len(parts)-1]
-		structName := strings.Title(strings.TrimSuffix(name, "s"))
+		structName := caser.String(strings.TrimSuffix(name, "s"))
 
 		dir := "app/models/" + strings.Join(parts[:len(parts)-1], "/")
 		filePath := fmt.Sprintf("%s/%s.go", dir, name)
@@ -201,7 +205,7 @@ var makeModelCmd = &cobra.Command{
 				continue
 			}
 
-			fieldName := strings.Title(parts[0])
+			fieldName := caser.String(parts[0])
 			tagParts := strings.Split(parts[1], ";")
 			fieldType := tagParts[0]
 			gormTags := strings.Join(tagParts[1:], ";")

--- a/config.yaml
+++ b/config.yaml
@@ -1,2 +1,2 @@
-version: "1.2.1"
+version: "1.2.2"
 name: "Goarchi Framework"

--- a/core/tools/GetIP.go
+++ b/core/tools/GetIP.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -12,24 +11,21 @@ type IPGeoData struct {
 	Country   string  `json:"country"`
 	City      string  `json:"city"`
 	ISP       string  `json:"isp"`
-	Query     string  `json:"query"` // IP Address
+	Query     string  `json:"query"`
 	Region    string  `json:"regionName"`
 	Latitude  float64 `json:"lat"`
 	Longitude float64 `json:"lon"`
-	Org       string  `json:"org"` // ISP or organization name
-	AS        string  `json:"as"`  // Autonomous System number
+	Org       string  `json:"org"`
+	AS        string  `json:"as"`  
 	Browser   string  `json:"browser"`
 	OS        string  `json:"os"`
 	Device    string  `json:"device"`
-	UserAgent string  `json:"user_agent"` // Full User-Agent string
+	UserAgent string  `json:"user_agent"`
 }
-
-// GetIPDetails fetches geo information from ip-api.com and user agent info.
 func GetIPDetails(userAgent string) (*IPGeoData, error) {
 	// URL untuk lookup IP
-	url := fmt.Sprintf("http://ip-api.com/json/")
+	url := "http://ip-api.com/json/"
 
-	// Mengirimkan request HTTP ke ip-api.com
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
@@ -54,7 +50,6 @@ func GetIPDetails(userAgent string) (*IPGeoData, error) {
 	return &data, nil
 }
 
-// ParseUserAgent untuk mendeteksi Browser, OS, dan Device dari user-agent string.
 func ParseUserAgent(userAgent string) (browser string, os string, device string) {
 	// Deteksi browser
 	if strings.Contains(userAgent, "Chrome") {
@@ -81,8 +76,6 @@ func ParseUserAgent(userAgent string) (browser string, os string, device string)
 	} else {
 		os = "Unknown"
 	}
-
-	// Deteksi perangkat (mobile/desktop)
 	if strings.Contains(userAgent, "Mobi") {
 		device = "Mobile"
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,9 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/gin-contrib/cors v1.7.7
 	github.com/gin-gonic/gin v1.12.0
+	github.com/go-playground/locales v0.14.1
+	github.com/go-playground/universal-translator v0.18.1
+	github.com/go-playground/validator/v10 v10.30.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/joho/godotenv v1.5.1
 	github.com/spf13/cobra v1.10.2
@@ -19,9 +22,6 @@ require (
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/bytedance/gopkg v0.1.4 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.30.2 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
@@ -61,6 +61,6 @@ require (
 	golang.org/x/crypto v0.51.0
 	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/text v0.37.0
 	google.golang.org/protobuf v1.36.11 // indirect
 )


### PR DESCRIPTION
- Replace strings.Title with golang.org/x/text/cases (deprecated since Go 1.18)
- Replace ioutil.ReadFile with os.ReadFile (deprecated since Go 1.19)
- Remove unused getEnv function in jwt.go
- Replace fmt.Errorf with errors.New for static error strings in jwt.go
- Handle error return from RegisterDefaultTranslations in validator.go
- Remove unnecessary fmt.Sprintf in GetIP.go
- Fix redundant newline in fmt.Println calls in make.go
- Fix ineffectual assignment in installRouter command
- Remove all emojis from make.go
- Add .github/workflows/ci.yml: build check, mod tidy, doctor, govulncheck, golangci-lint
- Add .github/workflows/release.yml: auto binary release on tag v*
- Bump version to 1.2.2